### PR TITLE
fix: update cache directory in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Windows / rpm-based distros are **not** supported. (PRs to improve this situatio
       - name: Cache compilation
         uses: actions/cache@v1
         with:
-          path: ~/.ccache
+          path: ~/.cache/ccache # on mac: ~/Library/Caches/ccache
           key: ccache
       - name: Setup ccache
         uses: alexjurkiewicz/setup-ccache@master


### PR DESCRIPTION
As of ccache 4.0, a new cache location scheme based on XDG is used. This commit updates the documentation example to use the correct location for linux (on recent runners at least), and adds in a comment the mac location. (I'm not sure why we were seeing this only on mac at first in #3 but as of now the change affects both OSs.)

It may also be worth double checking the .conf location, but this commit doesn't do that.

Crawl commits:
  https://github.com/crawl/crawl/commit/89d08c69976b
  https://github.com/crawl/crawl/commit/92a8e1e1ec88

Resolves #3